### PR TITLE
Disable protobuf 3rd party (otherwise use Conan package)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -119,6 +119,7 @@ class OpenCVConan(ConanFile):
         cmake.definitions['WITH_PNG'] = self.options.png
         cmake.definitions['WITH_JASPER'] = self.options.jasper
         cmake.definitions['WITH_OPENEXR'] = False
+        cmake.definitions['WITH_PROTOBUF'] = False
 
         # system libraries
         if self.settings.os == 'Linux':


### PR DESCRIPTION
As it is now, OpenCV recipe is using `protobuf` library from 3rdparties included in OpenCV repository. Disable it until we test Conan one.

This PR affects this one too: https://github.com/conan-community/conan-opencv/pull/6